### PR TITLE
Fixes DCV-403

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -501,6 +501,3 @@ DEPENDENCIES
   therubyracer (>= 0.12.2)
   uglifier (>= 1.3.0)
   unicorn
-
-BUNDLED WITH
-   1.11.2

--- a/app/controllers/concerns/dcv/catalog/browse_list_behavior.rb
+++ b/app/controllers/concerns/dcv/catalog/browse_list_behavior.rb
@@ -14,7 +14,7 @@ module Dcv::Catalog::BrowseListBehavior
 
   def refresh_browse_lists_cache
     if Rails.env == 'development' || ! Rails.cache.exist?(BROWSE_LISTS_KEY)
-      Rails.cache.write(BROWSE_LISTS_KEY, get_browse_lists);
+      Rails.cache.write(BROWSE_LISTS_KEY, get_browse_lists, expires_in: 24.hours);
     end
     @browse_lists = Rails.cache.read(BROWSE_LISTS_KEY)
   end
@@ -468,15 +468,13 @@ module Dcv::Catalog::BrowseListBehavior
 
     values_and_counts = {}
 
-    response = rsolr.get 'select', :params => {
+    response = rsolr.get 'select', :params => self.blacklight_config.default_solr_params.merge({
       :q  => '*:*',
-      :qt => 'search',
       :rows => 0,
-      :facet => true,
       :'facet.sort' => 'index', # We want Solr to order facets based on their type (alphabetically, numerically, etc.)
       :'facet.field' => [facet_field_name],
       ('f.' + facet_field_name + '.facet.limit').to_sym => -1,
-    }
+    })
 
     facet_response = response['facet_counts']['facet_fields'][facet_field_name]
     values_and_counts['value_pairs'] = {}


### PR DESCRIPTION
- Home page facet list solr query params should come from controller blacklight_config.default_solr_params
- Home page browse list cache should be refreshed periodically (now: every 24 hours)